### PR TITLE
Update CopilotKit MCP to streamable HTTP

### DIFF
--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -272,20 +272,19 @@ export interface CopilotRuntimeConstructorParams<T extends Parameter[] | [] = []
    * Required if `mcpServers` is provided.
    *
    * ```typescript
-   * import { experimental_createMCPClient } from "ai"; // Import from vercel ai library
-   * // ...
+   * // Example using HTTP Stream transport (recommended)
+   * // with a custom MCP HTTP client that implements the MCPClient interface.
+   * // See: registry quickstart HttpStreamClient for a reference implementation.
    * const runtime = new CopilotRuntime({
-   *   mcpServers: [{ endpoint: "..." }],
+   *   mcpServers: [{ endpoint: "https://your-mcp-server" }],
    *   async createMCPClient(config) {
-   *     return await experimental_createMCPClient({
-   *       transport: {
-   *         type: "sse",
-   *         url: config.endpoint,
-   *         headers: config.apiKey
-   *           ? { Authorization: `Bearer ${config.apiKey}` }
-   *           : undefined,
-   *       },
+   *     const { HttpStreamClient } = await import("@/registry/quickstarts/mcp-starter/utils/http-stream-client");
+   *     const client = new HttpStreamClient({
+   *       serverUrl: config.endpoint,
+   *       headers: config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : undefined,
    *     });
+   *     await client.connect();
+   *     return client;
    *   }
    * });
    * ```

--- a/docs/content/docs/(root)/connect-mcp-servers.mdx
+++ b/docs/content/docs/(root)/connect-mcp-servers.mdx
@@ -33,14 +33,14 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
 <Steps>
   <Step>
     ### Get an MCP Server
-    First, we need to make sure we have an MCP server to connect to. You can use any MCP SSE endpoint you have configured.
+    First, we need to make sure we have an MCP server to connect to. Use an MCP HTTP endpoint that supports streamable responses.
 
     <Accordions className="shadow-lg ring-1 ring-indigo-400 selected bg-gradient-to-r from-indigo-100/80 to-purple-200 dark:from-indigo-900/30 dark:to-purple-900/50">
       <Accordion title="Get an MCP Server from Composio">
         <p>
           Composio provides a registry of ready-to-use MCP servers with simple authentication and setup.
 
-          To get started, go to [Composio](https://mcp.composio.dev/), find a server the suits your needs and copy the SSE URL before continuing here.
+          To get started, go to [Composio](https://mcp.composio.dev/), find a server that suits your needs and copy the HTTP endpoint URL before continuing here.
         </p>
       </Accordion>
     </Accordions>
@@ -122,7 +122,7 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
             setMcpServers([
               {
                 // Try a sample MCP server at https://mcp.composio.dev/
-                endpoint: "your_mcp_sse_url",
+                endpoint: "https://your-mcp-http-endpoint",
               },
             ]);
           }, [setMcpServers]);

--- a/docs/content/docs/direct-to-llm/guides/model-context-protocol.mdx
+++ b/docs/content/docs/direct-to-llm/guides/model-context-protocol.mdx
@@ -33,14 +33,14 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
 <Steps>
   <Step>
     ### Get an MCP Server
-    First, we need to make sure we have an MCP server to connect to. You can use any MCP SSE endpoint you have configured.
+    First, we need to make sure we have an MCP server to connect to. Use an MCP HTTP endpoint that supports streamable responses.
 
     <Accordions className="shadow-lg ring-1 ring-indigo-400 selected bg-gradient-to-r from-indigo-100/80 to-purple-200 dark:from-indigo-900/30 dark:to-purple-900/50">
       <Accordion title="Get an MCP Server from Composio">
         <p>
           Composio provides a registry of ready-to-use MCP servers with simple authentication and setup.
 
-          To get started, go to [Composio](https://mcp.composio.dev/), find a server the suits your needs and copy the SSE URL before continuing here.
+          To get started, go to [Composio](https://mcp.composio.dev/), find a server that suits your needs and copy the HTTP endpoint URL before continuing here.
         </p>
       </Accordion>
     </Accordions>
@@ -122,7 +122,7 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
             setMcpServers([
               {
                 // Try a sample MCP server at https://mcp.composio.dev/
-                endpoint: "your_mcp_sse_url",
+                endpoint: "https://your-mcp-http-endpoint",
               },
             ]);
           }, [setMcpServers]);

--- a/registry/registry/quickstarts/mcp-starter/runtime.ts
+++ b/registry/registry/quickstarts/mcp-starter/runtime.ts
@@ -2,17 +2,18 @@ import {
   CopilotRuntime,
   OpenAIAdapter,
   copilotRuntimeNextJSAppRouterEndpoint,
+  MCPEndpointConfig,
 } from "@copilotkit/runtime";
 import { NextRequest } from "next/server";
 import { HttpStreamClient } from "@/registry/quickstarts/mcp-starter/utils/http-stream-client";
 
 const serviceAdapter = new OpenAIAdapter();
 const runtime = new CopilotRuntime({
-  createMCPClient: async (config) => {
+  createMCPClient: async (config: MCPEndpointConfig) => {
     const mcpClient = new HttpStreamClient({
       serverUrl: config.endpoint,
+      headers: config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : undefined,
     });
-
     await mcpClient.connect();
     return mcpClient;
   },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR updates CopilotKit's Model Context Protocol (MCP) direct-to-LLM support to use streamable HTTP instead of the deprecated Server-Sent Events (SSE).

Specifically, it:
- Updates the `createMCPClient` example in `copilot-runtime.ts` to recommend an HTTP stream transport client.
- Revises documentation (e.g., `connect-mcp-servers.mdx`, `model-context-protocol.mdx`) to reference HTTP endpoints instead of SSE URLs.
- Modifies the quickstart runtime (`mcp-starter/runtime.ts`) to use `HttpStreamClient` with optional authentication headers and types the `config` parameter.

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation

---
<a href="https://cursor.com/background-agent?bcId=bc-5436f0dd-6359-4d8f-8321-c4e810810c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5436f0dd-6359-4d8f-8321-c4e810810c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

